### PR TITLE
add define to supress macro warnings Wimplicit-fallthrough for Clang

### DIFF
--- a/asio/include/asio/yield.hpp
+++ b/asio/include/asio/yield.hpp
@@ -11,24 +11,32 @@
 #include "coroutine.hpp"
 
 #if defined(__clang__)
-# define GCC_SUPRESS_WARNING_FALLTROUGH _Pragma("GCC diagnostic push")\
+
+# define ASIO_SUPRESS_WARNING_FALLTROUGH _Pragma("clang diagnostic push")\
+										_Pragma("clang diagnostic ignored \"-Wimplicit-fallthrough\"")
+# define ASIO_SUPRESS_WARNING_POP  _Pragma("clang diagnostic pop")
+
+#elif defined(__GNUC__)
+
+#define ASIO_SUPRESS_WARNING_FALLTROUGH _Pragma("GCC diagnostic push")\
 										_Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")
-# define GCC_SUPRESS_WARNING_POP  _Pragma("GCC diagnostic pop")
+#define ASIO_SUPRESS_WARNING_POP _Pragma("GCC diagnostic pop")
+
 #else
-# define GCC_SUPRESS_WARNING_FALLTROUGH
-# define GCC_SUPRESS_WARNING_POP
+	#define ASIO_SUPRESS_WARNING_FALLTROUGH
+	#define ASIO_SUPRESS_WARNING_POP
 #endif
 
 #ifndef reenter
-# define reenter(c) GCC_SUPRESS_WARNING_FALLTROUGH \
+# define reenter(c) ASIO_SUPRESS_WARNING_FALLTROUGH \
 					ASIO_CORO_REENTER(c) \
-					GCC_SUPRESS_WARNING_POP
+					ASIO_SUPRESS_WARNING_POP
 #endif
 
 #ifndef yield
-# define yield  GCC_SUPRESS_WARNING_FALLTROUGH \
+# define yield  ASIO_SUPRESS_WARNING_FALLTROUGH \
 				ASIO_CORO_YIELD \
-			    GCC_SUPRESS_WARNING_POP
+			    ASIO_SUPRESS_WARNING_POP
 #endif
 
 #ifndef fork

--- a/asio/include/asio/yield.hpp
+++ b/asio/include/asio/yield.hpp
@@ -10,12 +10,25 @@
 
 #include "coroutine.hpp"
 
+#if defined(__clang__)
+# define GCC_SUPRESS_WARNING_FALLTROUGH _Pragma("GCC diagnostic push")\
+										_Pragma("GCC diagnostic ignored \"-Wimplicit-fallthrough\"")
+# define GCC_SUPRESS_WARNING_POP  _Pragma("GCC diagnostic pop")
+#else
+# define GCC_SUPRESS_WARNING_FALLTROUGH
+# define GCC_SUPRESS_WARNING_POP
+#endif
+
 #ifndef reenter
-# define reenter(c) ASIO_CORO_REENTER(c)
+# define reenter(c) GCC_SUPRESS_WARNING_FALLTROUGH \
+					ASIO_CORO_REENTER(c) \
+					GCC_SUPRESS_WARNING_POP
 #endif
 
 #ifndef yield
-# define yield ASIO_CORO_YIELD
+# define yield  GCC_SUPRESS_WARNING_FALLTROUGH \
+				ASIO_CORO_YIELD \
+			    GCC_SUPRESS_WARNING_POP
 #endif
 
 #ifndef fork


### PR DESCRIPTION
Link to task : https://app.clickup.com/t/9003015469/GF_CPP-731

Supress the warnings in the coroutine macro that was causing +400 warnings.