### PR TITLE
Always use atomic types for the work counter 

### DIFF
--- a/asio/include/asio/detail/atomic_count.hpp
+++ b/asio/include/asio/detail/atomic_count.hpp
@@ -17,9 +17,7 @@
 
 #include "asio/detail/config.hpp"
 
-#if !defined(ASIO_HAS_THREADS)
-// Nothing to include.
-#elif defined(ASIO_HAS_STD_ATOMIC)
+#if defined(ASIO_HAS_STD_ATOMIC)
 # include <atomic>
 #else // defined(ASIO_HAS_STD_ATOMIC)
 # include <boost/detail/atomic_count.hpp>
@@ -28,13 +26,7 @@
 namespace asio {
 namespace detail {
 
-#if !defined(ASIO_HAS_THREADS)
-typedef long atomic_count;
-inline void increment(atomic_count& a, long b) { a += b; }
-inline void decrement(atomic_count& a, long b) { a -= b; }
-inline void ref_count_up(atomic_count& a) { ++a; }
-inline bool ref_count_down(atomic_count& a) { return --a == 0; }
-#elif defined(ASIO_HAS_STD_ATOMIC)
+#if defined(ASIO_HAS_STD_ATOMIC)
 typedef std::atomic<long> atomic_count;
 inline void increment(atomic_count& a, long b) { a += b; }
 inline void decrement(atomic_count& a, long b) { a -= b; }

--- a/asio/include/asio/detail/scheduler.hpp
+++ b/asio/include/asio/detail/scheduler.hpp
@@ -89,7 +89,7 @@ public:
   // Notify that some work has started.
   void work_started()
   {
-    ++outstanding_work_;
+	  detail::ref_count_up(outstanding_work_);
   }
 
   // Used to compensate for a forthcoming work_finished call. Must be called
@@ -99,8 +99,10 @@ public:
   // Notify that some work has finished.
   void work_finished()
   {
-    if (--outstanding_work_ == 0)
+	if (detail::ref_count_down(outstanding_work_))
+	{
       stop();
+	}
   }
 
   // Return whether a handler can be dispatched immediately.


### PR DESCRIPTION
if ASIO_HAS_THREADS is disabled, then asio defaults to non-atomic counter types. We don't want that. 
Also make sure we're using atomic increment/decrement for the work counter. 